### PR TITLE
GCS related configuration moved to storage package

### DIFF
--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/bigquery/ScioContextSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/bigquery/ScioContextSyntax.scala
@@ -1,6 +1,5 @@
 package org.mkuthan.streamprocessing.infrastructure.bigquery
 
-import scala.language.implicitConversions
 import scala.reflect.runtime.universe.TypeTag
 import scala.reflect.ClassTag
 import scala.util.chaining.scalaUtilChainingOps
@@ -55,5 +54,7 @@ private[bigquery] class ScioContextOps(private val self: ScioContext) extends An
 }
 
 trait ScioContextSyntax {
+  import scala.language.implicitConversions
+
   implicit def bigQueryScioContextOps(sc: ScioContext): ScioContextOps = new ScioContextOps(sc)
 }

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/diagnostic/SCollectionSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/diagnostic/SCollectionSyntax.scala
@@ -24,7 +24,6 @@ private[diagnostic] class SCollectionOps[T: Coder: TypeTag: SumByKey](
   private val bqType = BigQueryType[T]
 
   private val bqConfiguration = FileLoadsConfiguration()
-    .withWriteDisposition(WriteDisposition.Truncate)
 
   def writeUnboundedDiagnosticToBigQuery(
       id: IoIdentifier[T],

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/diagnostic/SCollectionSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/diagnostic/SCollectionSyntax.scala
@@ -73,7 +73,6 @@ private[diagnostic] class SCollectionOps[T: Coder: TypeTag: SumByKey](
 }
 
 trait SCollectionSyntax {
-
   import scala.language.implicitConversions
 
   implicit def diagnosticSCollectionOps[T: Coder: TypeTag: SumByKey](sc: SCollection[T]): SCollectionOps[T] =

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/DlqConfiguration.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/DlqConfiguration.scala
@@ -10,6 +10,9 @@ import org.apache.beam.sdk.transforms.windowing.Window
 import org.apache.beam.sdk.values.WindowingStrategy.AccumulationMode
 import org.joda.time.Duration
 
+import org.mkuthan.streamprocessing.infrastructure.storage.NumShards
+import org.mkuthan.streamprocessing.infrastructure.storage.Prefix
+
 case class DlqConfiguration(
     prefix: Prefix = Prefix.Empty,
     numShards: NumShards = NumShards.RunnerSpecific,
@@ -35,15 +38,6 @@ case class DlqConfiguration(
 
   def withAllowedLateness(duration: Duration): DlqConfiguration =
     copy(allowedLateness = duration)
-
-  def configure(write: StorageWriteParam.Type): StorageWriteParam.Type =
-    params.foldLeft(write)((write, param) => param.configure(write))
-
-  private lazy val params: Set[StorageWriteParam] = Set(
-    JsonSuffix,
-    prefix,
-    numShards
-  )
 }
 
 object DlqConfiguration {

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntax.scala
@@ -27,7 +27,7 @@ private[dlq] class SCollectionOps[T <: AnyRef: Coder](private val self: SCollect
     val io = FileIO.write[String]()
       .via(TextIO.sink())
       .pipe(write => storageConfiguration.configure(write))
-      .to(bucket.id)
+      .to(bucket.url)
 
     val _ = self
       .withName(s"$id/Serialize")

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntax.scala
@@ -11,17 +11,23 @@ import org.apache.beam.sdk.io.TextIO
 
 import org.mkuthan.streamprocessing.infrastructure.common.IoIdentifier
 import org.mkuthan.streamprocessing.infrastructure.storage.StorageBucket
+import org.mkuthan.streamprocessing.infrastructure.storage.StorageConfiguration
+import org.mkuthan.streamprocessing.infrastructure.storage.Suffix
 import org.mkuthan.streamprocessing.shared.json.JsonSerde
-
 private[dlq] class SCollectionOps[T <: AnyRef: Coder](private val self: SCollection[T]) {
   def writeDeadLetterToStorageAsJson(
       id: IoIdentifier[T],
       bucket: StorageBucket[T],
       configuration: DlqConfiguration = DlqConfiguration()
   ): Unit = {
+    val storageConfiguration = StorageConfiguration()
+      .withPrefix(configuration.prefix)
+      .withSuffix(Suffix.Json)
+      .withNumShards(configuration.numShards)
+
     val io = FileIO.write[String]()
       .via(TextIO.sink())
-      .pipe(write => configuration.configure(write))
+      .pipe(write => storageConfiguration.configure(write))
       .to(bucket.id)
 
     val _ = self

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntax.scala
@@ -1,6 +1,5 @@
 package org.mkuthan.streamprocessing.infrastructure.dlq
 
-import scala.language.implicitConversions
 import scala.util.chaining._
 
 import com.spotify.scio.coders.Coder
@@ -40,6 +39,8 @@ private[dlq] class SCollectionOps[T <: AnyRef: Coder](private val self: SCollect
 }
 
 trait SCollectionSyntax {
+  import scala.language.implicitConversions
+
   implicit def dlqSCollectionOps[T <: AnyRef: Coder](sc: SCollection[T]): SCollectionOps[T] =
     new SCollectionOps(sc)
 }

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/pubsub/SCollectionSyntax.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/pubsub/SCollectionSyntax.scala
@@ -49,7 +49,6 @@ private[pubsub] class SCollectionDeadLetterOps[T <: AnyRef: Coder](private val s
 }
 
 trait SCollectionSyntax {
-
   import scala.language.implicitConversions
 
   implicit def pubsubSCollectionOps[T <: AnyRef: Coder](sc: SCollection[Message[T]]): SCollectionOps[T] =

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/storage/StorageBucket.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/storage/StorageBucket.scala
@@ -1,5 +1,5 @@
 package org.mkuthan.streamprocessing.infrastructure.storage
 
 case class StorageBucket[T](id: String) {
-  lazy val name: String = id.stripPrefix("gs://")
+  lazy val url: String = s"gs://$id"
 }

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/storage/StorageConfiguration.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/storage/StorageConfiguration.scala
@@ -1,0 +1,25 @@
+package org.mkuthan.streamprocessing.infrastructure.storage
+
+case class StorageConfiguration(
+    prefix: Prefix = Prefix.Empty,
+    suffix: Suffix = Suffix.Empty,
+    numShards: NumShards = NumShards.RunnerSpecific
+) {
+  def withPrefix(prefix: Prefix): StorageConfiguration =
+    copy(prefix = prefix)
+
+  def withSuffix(suffix: Suffix): StorageConfiguration =
+    copy(suffix = suffix)
+
+  def withNumShards(numShards: NumShards): StorageConfiguration =
+    copy(numShards = numShards)
+
+  def configure(write: StorageWriteParam.Type): StorageWriteParam.Type =
+    params.foldLeft(write)((write, param) => param.configure(write))
+
+  private lazy val params: Set[StorageWriteParam] = Set(
+    suffix,
+    prefix,
+    numShards
+  )
+}

--- a/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/storage/StorageParams.scala
+++ b/stream-processing-infrastructure/src/main/scala/org/mkuthan/streamprocessing/infrastructure/storage/StorageParams.scala
@@ -1,4 +1,4 @@
-package org.mkuthan.streamprocessing.infrastructure.dlq
+package org.mkuthan.streamprocessing.infrastructure.storage
 
 import org.apache.beam.sdk.io.FileIO
 
@@ -43,7 +43,22 @@ object Prefix {
   }
 }
 
-case object JsonSuffix extends StorageWriteParam {
-  override def configure(write: StorageWriteParam.Type): StorageWriteParam.Type =
-    write.withSuffix(".json")
+sealed trait Suffix extends StorageWriteParam
+
+object Suffix {
+  object Empty extends Suffix {
+    override def configure(write: StorageWriteParam.Type): StorageWriteParam.Type =
+      write.withSuffix("")
+  }
+
+  case class Explicit(value: String) extends Suffix {
+    require(value.nonEmpty)
+    override def configure(write: StorageWriteParam.Type): StorageWriteParam.Type =
+      write.withSuffix(value)
+  }
+
+  case object Json extends Suffix {
+    override def configure(write: StorageWriteParam.Type): StorageWriteParam.Type =
+      write.withSuffix(".json")
+  }
 }

--- a/stream-processing-infrastructure/src/test/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntaxTest.scala
+++ b/stream-processing-infrastructure/src/test/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntaxTest.scala
@@ -41,7 +41,7 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
         .testStream(sampleObjects)
         .writeDeadLetterToStorageAsJson(
           IoIdentifier[SampleClass]("any-id"),
-          StorageBucket[SampleClass](s"gs://$bucket"),
+          StorageBucket[SampleClass](bucket),
           configuration
         )
 
@@ -49,10 +49,9 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
 
       val windowStart = "2014-09-10T12:00:00.000Z"
       val windowEnd = "2014-09-10T12:10:00.000Z"
-      val shard = "00000-of-00001"
 
       eventually {
-        val results = readObjectLines(bucket, fileName(windowStart, windowEnd, shard))
+        val results = readObjectLines(bucket, fileName(windowStart, windowEnd))
           .map(JsonSerde.readJsonFromString[SampleClass](_).get)
 
         results should contain.only(SampleObject1, SampleObject2)
@@ -60,7 +59,7 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
     }
   }
 
-  it should "write on GCS as two JSON files if max records is reached" in withScioContext { sc =>
+  it should "write on GCS as two JSON files if dead letters overflows" in withScioContext { sc =>
     withBucket { bucket =>
       val sampleObjects = testStreamOf[SampleClass]
         .addElementsAtTime("2014-09-10T12:01:00.000Z", SampleObject1)
@@ -71,7 +70,7 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
         .testStream(sampleObjects)
         .writeDeadLetterToStorageAsJson(
           IoIdentifier[SampleClass]("any-id"),
-          StorageBucket[SampleClass](s"gs://$bucket"),
+          StorageBucket[SampleClass](bucket),
           configuration.withMaxRecords(1)
         )
 
@@ -79,21 +78,20 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
 
       val windowStart = "2014-09-10T12:00:00.000Z"
       val windowEnd = "2014-09-10T12:10:00.000Z"
-      val shard = "00000-of-00001"
 
       eventually {
-        val first = readObjectLines(bucket, fileName(windowStart, windowEnd, shard, pane = "0"))
+        val first = readObjectLines(bucket, fileName(windowStart, windowEnd, pane = Some(0)))
           .map(JsonSerde.readJsonFromString[SampleClass](_).get)
-        val second = readObjectLines(bucket, fileName(windowStart, windowEnd, shard, pane = "1"))
+        val second = readObjectLines(bucket, fileName(windowStart, windowEnd, pane = Some(1)))
           .map(JsonSerde.readJsonFromString[SampleClass](_).get)
 
-        first should contain.only(SampleObject1)
-        second should contain.only(SampleObject2)
+        first should contain only SampleObject1
+        second should contain only SampleObject2
       }
     }
   }
 
-  ignore should "write on GCS as two JSON files if there are two windows" in withScioContext { sc =>
+  it should "write on GCS two JSON files if there are two windows" in withScioContext { sc =>
     withBucket { bucket =>
       val sampleObjects = testStreamOf[SampleClass]
         .addElementsAtTime("2014-09-10T12:01:00.000Z", SampleObject1)
@@ -104,7 +102,8 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
         .testStream(sampleObjects)
         .writeDeadLetterToStorageAsJson(
           IoIdentifier[SampleClass]("any-id"),
-          StorageBucket[SampleClass](s"gs://$bucket")
+          StorageBucket[SampleClass](bucket),
+          configuration
         )
 
       sc.run().waitUntilDone()
@@ -113,23 +112,30 @@ class SCollectionSyntaxTest extends AnyFlatSpec with Matchers
       val firstWindowEnd = "2014-09-10T12:10:00.000Z"
       val secondWindowStart = "2014-09-10T12:10:00.000Z"
       val secondWindowEnd = "2014-09-10T12:20:00.000Z"
-      val shard = "00000-of-00001" // shard magic, the reason why the test is ignored
 
       eventually {
-        val first = readObjectLines(bucket, fileName(firstWindowStart, firstWindowEnd, shard))
+        val first = readObjectLines(bucket, fileName(firstWindowStart, firstWindowEnd))
           .map(JsonSerde.readJsonFromString[SampleClass](_).get)
-        val second = readObjectLines(bucket, fileName(secondWindowStart, secondWindowEnd, shard))
+        val second = readObjectLines(bucket, fileName(secondWindowStart, secondWindowEnd))
           .map(JsonSerde.readJsonFromString[SampleClass](_).get)
 
-        first should contain.only(SampleObject1)
-        second should contain.only(SampleObject2)
+        first should contain only SampleObject1
+        second should contain only SampleObject2
       }
     }
   }
 
-  def fileName(windowStart: String, windowEnd: String, shard: String): String =
-    s"$windowStart-$windowEnd-$shard.json"
-
-  def fileName(windowStart: String, windowEnd: String, shard: String, pane: String): String =
-    s"$windowStart-$windowEnd-$pane-$shard.json"
+  def fileName(
+      windowStart: String,
+      windowEnd: String,
+      shard: Int = 0,
+      numShards: Int = 1,
+      pane: Option[Int] = None
+  ): String = {
+    val shardFragment = "%05d-of-%05d".formatted(shard, numShards)
+    pane match {
+      case Some(paneFragment) => s"$windowStart-$windowEnd-$paneFragment-$shardFragment.json"
+      case None               => s"$windowStart-$windowEnd-$shardFragment.json"
+    }
+  }
 }

--- a/stream-processing-infrastructure/src/test/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntaxTest.scala
+++ b/stream-processing-infrastructure/src/test/scala/org/mkuthan/streamprocessing/infrastructure/dlq/SCollectionSyntaxTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.matchers.should.Matchers
 
 import org.mkuthan.streamprocessing.infrastructure._
 import org.mkuthan.streamprocessing.infrastructure.common.IoIdentifier
+import org.mkuthan.streamprocessing.infrastructure.storage.NumShards
 import org.mkuthan.streamprocessing.infrastructure.storage.StorageBucket
 import org.mkuthan.streamprocessing.infrastructure.IntegrationTestFixtures
 import org.mkuthan.streamprocessing.infrastructure.IntegrationTestFixtures.SampleClass

--- a/stream-processing-shared/src/main/scala/org/mkuthan/streamprocessing/shared/scio/SCollectionSyntax.scala
+++ b/stream-processing-shared/src/main/scala/org/mkuthan/streamprocessing/shared/scio/SCollectionSyntax.scala
@@ -1,7 +1,5 @@
 package org.mkuthan.streamprocessing.shared.scio
 
-import scala.language.implicitConversions
-
 import com.spotify.scio.coders.Coder
 import com.spotify.scio.values.SCollection
 import com.spotify.scio.values.SideOutput
@@ -45,6 +43,8 @@ private[scio] class SCollectionOps[T: Coder](private val self: SCollection[T]) {
 }
 
 trait SCollectionSyntax {
+  import scala.language.implicitConversions
+
   implicit def coreSCollectionOps[T: Coder](sc: SCollection[T]): SCollectionOps[T] =
     new SCollectionOps(sc)
 

--- a/stream-processing-shared/src/test/scala/org/mkuthan/streamprocessing/shared/json/JsonSerdeTest.scala
+++ b/stream-processing-shared/src/test/scala/org/mkuthan/streamprocessing/shared/json/JsonSerdeTest.scala
@@ -8,7 +8,6 @@ import org.joda.time.Instant
 import org.joda.time.LocalDate
 import org.joda.time.LocalDateTime
 import org.joda.time.LocalTime
-import org.scalacheck._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.TryValues._
@@ -31,8 +30,6 @@ object JsonSerdeTest extends JodaTimeArbitrary {
       localDate: LocalDate,
       localTime: LocalTime
   )
-
-  implicit val sampleClassArbitrary = implicitly[Arbitrary[SampleClass]]
 }
 
 class JsonSerdeTest extends AnyFlatSpec

--- a/stream-processing-test/src/main/scala/org/mkuthan/streamprocessing/test/scio/TimestampedMatchers.scala
+++ b/stream-processing-test/src/main/scala/org/mkuthan/streamprocessing/test/scio/TimestampedMatchers.scala
@@ -26,25 +26,8 @@ trait TimestampedMatchers extends InstantSyntax {
   def inFinalPane[T: ClassTag](begin: String, end: String)(matcher: MatcherBuilder[T]): Matcher[T] =
     inFinalPane(new IntervalWindow(begin.toInstant, end.toInstant))(matcher)
 
-  def inOnlyPane[T: ClassTag](begin: String, end: String)(matcher: MatcherBuilder[T]): Matcher[T] = {
-    val window = new IntervalWindow(begin.toInstant, end.toInstant)
-    matcher match {
-      case value: SingleMatcher[T, _] =>
-        value.matcher(_.inOnlyPane(window))
-      case value: IterableMatcher[T, _] =>
-        value.matcher(_.inOnlyPane(window))
-    }
-  }
-
-  def inWindow[T: ClassTag](begin: String, end: String)(matcher: MatcherBuilder[T]): Matcher[T] = {
-    val window = new IntervalWindow(begin.toInstant, end.toInstant)
-    matcher match {
-      case value: SingleMatcher[T, _] =>
-        value.matcher(_.inWindow(window))
-      case value: IterableMatcher[T, _] =>
-        value.matcher(_.inWindow(window))
-    }
-  }
+  def inWindow[T: ClassTag, B: ClassTag](begin: String, end: String)(matcher: IterableMatcher[T, B]): Matcher[T] =
+    inWindow(new IntervalWindow(begin.toInstant, end.toInstant))(matcher)
 
   /**
    * Assert that the SCollection contains the provided element at given time without making assumptions about other

--- a/toll-application/src/test/scala/org/mkuthan/streamprocessing/toll/application/streaming/TollApplicationTest.scala
+++ b/toll-application/src/test/scala/org/mkuthan/streamprocessing/toll/application/streaming/TollApplicationTest.scala
@@ -32,12 +32,12 @@ class TollApplicationTest extends AnyFlatSpec with Matchers
     JobTest[TollApplication.type]
       .args(
         "--entrySubscription=projects/any-id/subscriptions/entry-subscription",
-        "--entryDlq=gs://entry_dlq",
+        "--entryDlq=entry_dlq",
         "--exitSubscription=projects/any-id/subscriptions/exit-subscription",
-        "--exitDlq=gs://exit_dlq",
+        "--exitDlq=exit_dlq",
         "--vehicleRegistrationSubscription=projects/any-id/subscriptions/vehicle-registration-subscription",
         "--vehicleRegistrationTable=toll.vehicle_registration",
-        "--vehicleRegistrationDlq=gs://vehicle_registration_dlq",
+        "--vehicleRegistrationDlq=vehicle_registration_dlq",
         "--entryStatsTable=toll.entry_stats",
         "--totalVehicleTimeTable=toll.total_vehicle_time",
         "--totalVehicleTimeDiagnosticTable=toll.total_vehicle_time_diagnostic",


### PR DESCRIPTION
Closes #94

- [x] DLQ storage related configuration in the storage package
- [x] Fix "write on GCS as two JSON files if there are two windows" DLQ test scenario